### PR TITLE
Multiverse register issuance

### DIFF
--- a/tapdb/universe_forest.go
+++ b/tapdb/universe_forest.go
@@ -7,9 +7,12 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/lightninglabs/taproot-assets/asset"
 	"github.com/lightninglabs/taproot-assets/mssmt"
+	"github.com/lightninglabs/taproot-assets/proof"
 	"github.com/lightninglabs/taproot-assets/tapdb/sqlc"
 	"github.com/lightninglabs/taproot-assets/universe"
 )
+
+const mssmtNamespace = "multiverse"
 
 type (
 	BaseUniverseRoot = sqlc.UniverseRootsRow
@@ -18,6 +21,8 @@ type (
 // BaseUniverseForestStore is used to interact with a set of base universe
 // roots, also known as a universe forest.
 type BaseUniverseForestStore interface {
+	BaseUniverseStore
+
 	UniverseRoots(ctx context.Context) ([]BaseUniverseRoot, error)
 }
 
@@ -124,4 +129,66 @@ func (b *BaseUniverseForest) RootNodes(
 	}
 
 	return uniRoots, nil
+}
+
+// RegisterIssuance inserts a new minting leaf within the universe tree, stored
+// at the base key.
+func (b *BaseUniverseForest) RegisterIssuance(ctx context.Context,
+	id universe.Identifier, key universe.BaseKey,
+	leaf *universe.MintingLeaf,
+	metaReveal *proof.MetaReveal) (*universe.IssuanceProof, error) {
+
+	var (
+		writeTx       BaseUniverseForestOptions
+		issuanceProof *universe.IssuanceProof
+	)
+
+	dbErr := b.db.ExecTx(
+		ctx, &writeTx, func(dbTx BaseUniverseForestStore) error {
+			// Register issuance in the asset (group) specific
+			// universe tree.
+			var (
+				universeRoot mssmt.Node
+				err          error
+			)
+			issuanceProof, universeRoot, err = universeRegisterIssuance(
+				ctx, dbTx, id, key, leaf, metaReveal,
+			)
+
+			// Retrieve a handle to the multiverse tree so that we
+			// can update the tree by inserting a new issuance.
+			multiverseTree := mssmt.NewCompactedTree(
+				newTreeStoreWrapperTx(dbTx, mssmtNamespace),
+			)
+
+			// Construct a leaf node for insertion into the
+			// multiverse tree.
+			universeRootHash := universeRoot.NodeHash()
+			assetGroupSum := universeRoot.NodeSum()
+
+			leafNode := mssmt.NewLeafNode(
+				universeRootHash[:], assetGroupSum,
+			)
+
+			// Use asset ID (or asset group hash) as the leaf node
+			// key. This is the same as the asset specific universe
+			// ID.
+			leafNodeKey := id.Bytes()
+
+			_, err = multiverseTree.Insert(
+				ctx, leafNodeKey, leafNode,
+			)
+			if err != nil {
+				return err
+			}
+
+			return err
+		},
+	)
+
+	if dbErr != nil {
+		return nil, dbErr
+	}
+
+	return issuanceProof, nil
 }

--- a/universe/base.go
+++ b/universe/base.go
@@ -202,8 +202,8 @@ func (a *MintingArchive) RegisterIssuance(ctx context.Context, id Identifier,
 
 	// Now that we know the proof is valid, we'll insert it into the base
 	// universe backend, and return the new issuance proof.
-	issuanceProof, err := baseUni.RegisterIssuance(
-		ctx, key, leaf, assetSnapshot.MetaReveal,
+	issuanceProof, err := a.cfg.UniverseForest.RegisterIssuance(
+		ctx, id, key, leaf, assetSnapshot.MetaReveal,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("unable to register new "+

--- a/universe/interface.go
+++ b/universe/interface.go
@@ -382,10 +382,11 @@ type Syncer interface {
 // DiffEngine is a Universe diff engine that can be used to compare the state
 // of two universes and find the set of assets that are different between them.
 type DiffEngine interface {
-	BaseForest
-
 	// RootNode returns the root node for a given base universe.
 	RootNode(ctx context.Context, id Identifier) (BaseRoot, error)
+
+	// RootNodes returns the set of root nodes for all known universes.
+	RootNodes(ctx context.Context) ([]BaseRoot, error)
 
 	// MintingKeys returns all the keys inserted in the universe.
 	MintingKeys(ctx context.Context, id Identifier) ([]BaseKey, error)

--- a/universe/interface.go
+++ b/universe/interface.go
@@ -41,14 +41,20 @@ type Identifier struct {
 	GroupKey *btcec.PublicKey
 }
 
-// String returns a string representation of the ID.
-func (i *Identifier) String() string {
+// Bytes returns a bytes representation of the ID.
+func (i *Identifier) Bytes() [32]byte {
 	if i.GroupKey != nil {
 		h := sha256.Sum256(schnorr.SerializePubKey(i.GroupKey))
-		return hex.EncodeToString(h[:])
+		return h
 	}
 
-	return hex.EncodeToString(i.AssetID[:])
+	return i.AssetID
+}
+
+// String returns a string representation of the ID.
+func (i *Identifier) String() string {
+	idBytes := i.Bytes()
+	return hex.EncodeToString(idBytes[:])
 }
 
 // StringForLog returns a string representation of the ID for logging.

--- a/universe/interface.go
+++ b/universe/interface.go
@@ -222,6 +222,10 @@ type BaseForest interface {
 	// of assets tracked in the base Universe.
 	RootNodes(ctx context.Context) ([]BaseRoot, error)
 
+	RegisterIssuance(ctx context.Context, id Identifier, key BaseKey,
+		leaf *MintingLeaf,
+		metaReveal *proof.MetaReveal) (*IssuanceProof, error)
+
 	// TODO(roasbeef): other stats stuff here, like total number of assets, etc
 	//  * also eventually want pull/fetch stats, can be pulled out into another instance
 }


### PR DESCRIPTION
This PR contains new functionality for registering an asset issuance in a multiverse MS-SMT.

Depends on https://github.com/lightninglabs/taproot-assets/pull/346 . Will be removed from draft once https://github.com/lightninglabs/taproot-assets/pull/346 is merged.